### PR TITLE
Add optional adapter and prompt mechanisms

### DIFF
--- a/main.py
+++ b/main.py
@@ -23,6 +23,15 @@ def parse_agrs():
     parser.add_argument('--threshold', type=int, default=3, help='the cut off frequency for the words.')
     parser.add_argument('--num_workers', type=int, default=2, help='the number of workers for dataloader.')
     parser.add_argument('--batch_size', type=int, default=16, help='the number of samples for a batch')
+    parser.add_argument('--use_note', action='store_true', help='use impression text as additional input')
+    parser.add_argument('--use_labels', action='store_true', help='use CheXpert labels for classification')
+    parser.add_argument('--text_encoder', type=str, default='bert-base-uncased', help='pretrained text encoder name')
+    parser.add_argument('--max_text_len', type=int, default=128, help='maximum length of note tokens')
+    parser.add_argument('--lambda_cls', type=float, default=1.0, help='loss weight for classification branch')
+    parser.add_argument('--use_adapter', action='store_true', help='enable adapter modules for few-shot tuning')
+    parser.add_argument('--adapter_dim', type=int, default=64, help='bottleneck dimension of adapters')
+    parser.add_argument('--use_prompt', action='store_true', help='enable learnable prompt tokens for few-shot tuning')
+    parser.add_argument('--prompt_len', type=int, default=5, help='number of prompt tokens')
 
     # Model settings (for visual extractor)
     parser.add_argument('--visual_extractor', type=str, default='resnet101', help='the visual extractor to be used.')
@@ -98,14 +107,19 @@ def main():
 
     # create tokenizer
     tokenizer = Tokenizer(args)
+    if args.use_note:
+        from transformers import AutoTokenizer
+        note_tokenizer = AutoTokenizer.from_pretrained(args.text_encoder)
+    else:
+        note_tokenizer = None
 
     # create data loader
-    train_dataloader = R2DataLoader(args, tokenizer, split='train', shuffle=True)
-    val_dataloader = R2DataLoader(args, tokenizer, split='val', shuffle=False)
-    test_dataloader = R2DataLoader(args, tokenizer, split='test', shuffle=False)
+    train_dataloader = R2DataLoader(args, tokenizer, split='train', shuffle=True, note_tokenizer=note_tokenizer)
+    val_dataloader = R2DataLoader(args, tokenizer, split='val', shuffle=False, note_tokenizer=note_tokenizer)
+    test_dataloader = R2DataLoader(args, tokenizer, split='test', shuffle=False, note_tokenizer=note_tokenizer)
 
     # build model architecture
-    model = R2GenModel(args, tokenizer)
+    model = R2GenModel(args, tokenizer, note_tokenizer=note_tokenizer)
 
     # get function handles of loss and metrics
     criterion = compute_loss

--- a/models/r2gen.py
+++ b/models/r2gen.py
@@ -4,15 +4,46 @@ import numpy as np
 
 from modules.visual_extractor import VisualExtractor
 from modules.encoder_decoder import EncoderDecoder
+try:
+    from transformers import AutoModel
+except ImportError:
+    AutoModel = None
 
 
 class R2GenModel(nn.Module):
-    def __init__(self, args, tokenizer):
+    def __init__(self, args, tokenizer, note_tokenizer=None):
         super(R2GenModel, self).__init__()
         self.args = args
         self.tokenizer = tokenizer
+        self.note_tokenizer = note_tokenizer
+
+        self.use_note = getattr(args, 'use_note', False)
+        self.use_labels = getattr(args, 'use_labels', False)
+        self.use_adapter = getattr(args, 'use_adapter', False)
+        self.adapter_dim = getattr(args, 'adapter_dim', 64)
+        self.use_prompt = getattr(args, 'use_prompt', False)
+        self.prompt_len = getattr(args, 'prompt_len', 5)
+
         self.visual_extractor = VisualExtractor(args)
+        self.img_proj = nn.Linear(args.d_vf, args.d_model)
+
+        if self.use_note and AutoModel is not None:
+            self.text_encoder = AutoModel.from_pretrained(args.text_encoder)
+            self.text_proj = nn.Linear(self.text_encoder.config.hidden_size, args.d_model)
+            self.modal_embed = nn.Parameter(torch.zeros(2, args.d_model))
+        else:
+            self.text_encoder = None
+
+        if self.use_labels:
+            cls_dim = args.d_vf if args.dataset_name != 'iu_xray' else args.d_vf * 2
+            self.classifier = nn.Linear(cls_dim, 14)
+        else:
+            self.classifier = None
+
         self.encoder_decoder = EncoderDecoder(args, tokenizer)
+
+        if self.use_prompt:
+            self.prompt_embeddings = nn.Parameter(torch.randn(self.prompt_len, args.d_model))
         if args.dataset_name == 'iu_xray':
             self.forward = self.forward_iu_xray
         else:
@@ -23,26 +54,58 @@ class R2GenModel(nn.Module):
         params = sum([np.prod(p.size()) for p in model_parameters])
         return super().__str__() + '\nTrainable parameters: {}'.format(params)
 
-    def forward_iu_xray(self, images, targets=None, mode='train'):
+    def forward_iu_xray(self, images, targets=None, mode='train', note_ids=None, note_mask=None):
         att_feats_0, fc_feats_0 = self.visual_extractor(images[:, 0])
         att_feats_1, fc_feats_1 = self.visual_extractor(images[:, 1])
         fc_feats = torch.cat((fc_feats_0, fc_feats_1), dim=1)
         att_feats = torch.cat((att_feats_0, att_feats_1), dim=1)
-        if mode == 'train':
-            output = self.encoder_decoder(fc_feats, att_feats, targets, mode='forward')
-        elif mode == 'sample':
-            output, _ = self.encoder_decoder(fc_feats, att_feats, mode='sample')
-        else:
-            raise ValueError
-        return output
+        att_feats = self.img_proj(att_feats)
 
-    def forward_mimic_cxr(self, images, targets=None, mode='train'):
-        att_feats, fc_feats = self.visual_extractor(images)
+        if self.use_note and note_ids is not None and self.text_encoder is not None:
+            txt = self.text_encoder(input_ids=note_ids, attention_mask=note_mask).last_hidden_state
+            txt = self.text_proj(txt)
+            img = att_feats + self.modal_embed[0]
+            txt = txt + self.modal_embed[1]
+            att_feats = torch.cat([img, txt], dim=1)
+
+        if self.use_prompt:
+            bs = att_feats.size(0)
+            prompts = self.prompt_embeddings.unsqueeze(0).expand(bs, -1, -1)
+            att_feats = torch.cat([prompts, att_feats], dim=1)
+
         if mode == 'train':
             output = self.encoder_decoder(fc_feats, att_feats, targets, mode='forward')
         elif mode == 'sample':
             output, _ = self.encoder_decoder(fc_feats, att_feats, mode='sample')
         else:
             raise ValueError
-        return output
+
+        cls_logits = self.classifier(fc_feats) if self.classifier is not None else None
+        return output, cls_logits
+
+    def forward_mimic_cxr(self, images, targets=None, mode='train', note_ids=None, note_mask=None):
+        att_feats, fc_feats = self.visual_extractor(images)
+        att_feats = self.img_proj(att_feats)
+
+        if self.use_note and note_ids is not None and self.text_encoder is not None:
+            txt = self.text_encoder(input_ids=note_ids, attention_mask=note_mask).last_hidden_state
+            txt = self.text_proj(txt)
+            img = att_feats + self.modal_embed[0]
+            txt = txt + self.modal_embed[1]
+            att_feats = torch.cat([img, txt], dim=1)
+
+        if self.use_prompt:
+            bs = att_feats.size(0)
+            prompts = self.prompt_embeddings.unsqueeze(0).expand(bs, -1, -1)
+            att_feats = torch.cat([prompts, att_feats], dim=1)
+
+        if mode == 'train':
+            output = self.encoder_decoder(fc_feats, att_feats, targets, mode='forward')
+        elif mode == 'sample':
+            output, _ = self.encoder_decoder(fc_feats, att_feats, mode='sample')
+        else:
+            raise ValueError
+
+        cls_logits = self.classifier(fc_feats) if self.classifier is not None else None
+        return output, cls_logits
 

--- a/modules/dataloaders.py
+++ b/modules/dataloaders.py
@@ -4,15 +4,21 @@ from torchvision import transforms
 from torch.utils.data import DataLoader
 from .datasets import IuxrayMultiImageDataset, MimiccxrSingleImageDataset
 
+try:
+    from transformers import AutoTokenizer
+except ImportError:  # transformers may not be available during static checks
+    AutoTokenizer = None
+
 
 class R2DataLoader(DataLoader):
-    def __init__(self, args, tokenizer, split, shuffle):
+    def __init__(self, args, tokenizer, split, shuffle, note_tokenizer=None):
         self.args = args
         self.dataset_name = args.dataset_name
         self.batch_size = args.batch_size
         self.shuffle = shuffle
         self.num_workers = args.num_workers
         self.tokenizer = tokenizer
+        self.note_tokenizer = note_tokenizer
         self.split = split
 
         if split == 'train':
@@ -31,9 +37,13 @@ class R2DataLoader(DataLoader):
                                      (0.229, 0.224, 0.225))])
 
         if self.dataset_name == 'iu_xray':
-            self.dataset = IuxrayMultiImageDataset(self.args, self.tokenizer, self.split, transform=self.transform)
+            self.dataset = IuxrayMultiImageDataset(
+                self.args, self.tokenizer, self.split, transform=self.transform, note_tokenizer=self.note_tokenizer
+            )
         else:
-            self.dataset = MimiccxrSingleImageDataset(self.args, self.tokenizer, self.split, transform=self.transform)
+            self.dataset = MimiccxrSingleImageDataset(
+                self.args, self.tokenizer, self.split, transform=self.transform, note_tokenizer=self.note_tokenizer
+            )
 
         self.init_kwargs = {
             'dataset': self.dataset,
@@ -46,7 +56,12 @@ class R2DataLoader(DataLoader):
 
     @staticmethod
     def collate_fn(data):
-        images_id, images, reports_ids, reports_masks, seq_lengths = zip(*data)
+        # support optional note and label information
+        if len(data[0]) == 5:
+            images_id, images, reports_ids, reports_masks, seq_lengths = zip(*data)
+            note_ids = note_masks = labels = None
+        else:
+            images_id, images, reports_ids, reports_masks, seq_lengths, note_ids, note_masks, labels = zip(*data)
         images = torch.stack(images, 0)
         max_seq_length = max(seq_lengths)
 
@@ -59,5 +74,18 @@ class R2DataLoader(DataLoader):
         for i, report_masks in enumerate(reports_masks):
             targets_masks[i, :len(report_masks)] = report_masks
 
-        return images_id, images, torch.LongTensor(targets), torch.FloatTensor(targets_masks)
+        batch = [images_id, images, torch.LongTensor(targets), torch.FloatTensor(targets_masks)]
+
+        if note_ids is not None and note_masks is not None:
+            max_note_len = max(len(n) for n in note_ids)
+            notes = np.zeros((len(note_ids), max_note_len), dtype=int)
+            note_mask_mat = np.zeros((len(note_ids), max_note_len), dtype=int)
+            for i, n in enumerate(note_ids):
+                notes[i, :len(n)] = n
+            for i, m in enumerate(note_masks):
+                note_mask_mat[i, :len(m)] = m
+            batch.extend([torch.LongTensor(notes), torch.LongTensor(note_mask_mat)])
+            if labels is not None:
+                batch.append(torch.FloatTensor(labels))
+        return tuple(batch)
 

--- a/modules/datasets.py
+++ b/modules/datasets.py
@@ -6,19 +6,36 @@ from torch.utils.data import Dataset
 
 
 class BaseDataset(Dataset):
-    def __init__(self, args, tokenizer, split, transform=None):
+    """Base dataset used for both IU X-Ray and MIMIC-CXR."""
+
+    def __init__(self, args, tokenizer, split, transform=None, note_tokenizer=None):
         self.image_dir = args.image_dir
         self.ann_path = args.ann_path
         self.max_seq_length = args.max_seq_length
         self.split = split
         self.tokenizer = tokenizer
+        self.note_tokenizer = note_tokenizer
         self.transform = transform
+        self.use_note = getattr(args, 'use_note', False)
+        self.use_labels = getattr(args, 'use_labels', False)
+
         self.ann = json.loads(open(self.ann_path, 'r').read())
 
         self.examples = self.ann[self.split]
         for i in range(len(self.examples)):
             self.examples[i]['ids'] = tokenizer(self.examples[i]['report'])[:self.max_seq_length]
             self.examples[i]['mask'] = [1] * len(self.examples[i]['ids'])
+            if self.use_note and 'impression' in self.examples[i] and self.note_tokenizer is not None:
+                note_encoded = self.note_tokenizer(
+                    self.examples[i]['impression'],
+                    truncation=True,
+                    max_length=getattr(args, 'max_text_len', 128),
+                    padding='max_length'
+                )
+                self.examples[i]['note_ids'] = note_encoded['input_ids']
+                self.examples[i]['note_mask'] = note_encoded['attention_mask']
+            if self.use_labels and 'labels' in self.examples[i]:
+                self.examples[i]['labels'] = self.examples[i]['labels']
 
     def __len__(self):
         return len(self.examples)
@@ -53,5 +70,8 @@ class MimiccxrSingleImageDataset(BaseDataset):
         report_ids = example['ids']
         report_masks = example['mask']
         seq_length = len(report_ids)
-        sample = (image_id, image, report_ids, report_masks, seq_length)
+        note_ids = example.get('note_ids', None)
+        note_mask = example.get('note_mask', None)
+        labels = example.get('labels', None)
+        sample = (image_id, image, report_ids, report_masks, seq_length, note_ids, note_mask, labels)
         return sample

--- a/modules/encoder_decoder.py
+++ b/modules/encoder_decoder.py
@@ -116,19 +116,29 @@ class Decoder(nn.Module):
 
 
 class DecoderLayer(nn.Module):
-    def __init__(self, d_model, self_attn, src_attn, feed_forward, dropout, rm_num_slots, rm_d_model):
+    def __init__(self, d_model, self_attn, src_attn, feed_forward, dropout, rm_num_slots, rm_d_model, use_adapter=False, adapter_dim=64):
         super(DecoderLayer, self).__init__()
         self.d_model = d_model
         self.self_attn = self_attn
         self.src_attn = src_attn
         self.feed_forward = feed_forward
         self.sublayer = clones(ConditionalSublayerConnection(d_model, dropout, rm_num_slots, rm_d_model), 3)
-
+        self.use_adapter = use_adapter
+        if use_adapter:
+            self.adapter = nn.Sequential(
+                nn.Linear(d_model, adapter_dim),
+                nn.ReLU(inplace=True),
+                nn.Linear(adapter_dim, d_model),
+            )
+        
     def forward(self, x, hidden_states, src_mask, tgt_mask, memory):
         m = hidden_states
         x = self.sublayer[0](x, lambda x: self.self_attn(x, x, x, tgt_mask), memory)
         x = self.sublayer[1](x, lambda x: self.src_attn(x, m, m, src_mask), memory)
-        return self.sublayer[2](x, self.feed_forward, memory)
+        x = self.sublayer[2](x, self.feed_forward, memory)
+        if self.use_adapter:
+            x = x + self.adapter(x)
+        return x
 
 
 class ConditionalSublayerConnection(nn.Module):
@@ -311,7 +321,17 @@ class EncoderDecoder(AttModel):
         model = Transformer(
             Encoder(EncoderLayer(self.d_model, c(attn), c(ff), self.dropout), self.num_layers),
             Decoder(
-                DecoderLayer(self.d_model, c(attn), c(attn), c(ff), self.dropout, self.rm_num_slots, self.rm_d_model),
+                DecoderLayer(
+                    self.d_model,
+                    c(attn),
+                    c(attn),
+                    c(ff),
+                    self.dropout,
+                    self.rm_num_slots,
+                    self.rm_d_model,
+                    use_adapter=self.use_adapter,
+                    adapter_dim=self.adapter_dim,
+                ),
                 self.num_layers),
             lambda x: x,
             nn.Sequential(Embeddings(self.d_model, tgt_vocab), c(position)),
@@ -332,6 +352,8 @@ class EncoderDecoder(AttModel):
         self.rm_num_slots = args.rm_num_slots
         self.rm_num_heads = args.rm_num_heads
         self.rm_d_model = args.rm_d_model
+        self.use_adapter = getattr(args, 'use_adapter', False)
+        self.adapter_dim = getattr(args, 'adapter_dim', 64)
 
         tgt_vocab = self.vocab_size + 1
 

--- a/modules/loss.py
+++ b/modules/loss.py
@@ -16,7 +16,11 @@ class LanguageModelCriterion(nn.Module):
         return output
 
 
-def compute_loss(output, reports_ids, reports_masks):
+def compute_loss(output, reports_ids, reports_masks, cls_logits=None, labels=None, lambda_cls=1.0):
+    """Compute generation loss and optional classification loss."""
     criterion = LanguageModelCriterion()
     loss = criterion(output, reports_ids[:, 1:], reports_masks[:, 1:]).mean()
+    if cls_logits is not None and labels is not None:
+        bce = nn.BCEWithLogitsLoss()(cls_logits, labels)
+        loss = loss + lambda_cls * bce
     return loss

--- a/modules/trainer.py
+++ b/modules/trainer.py
@@ -189,11 +189,17 @@ class Trainer(BaseTrainer):
 
         train_loss = 0
         self.model.train()
-        for batch_idx, (images_id, images, reports_ids, reports_masks) in enumerate(self.train_dataloader):
-            images, reports_ids, reports_masks = images.to(self.device), reports_ids.to(self.device), reports_masks.to(
-                self.device)
-            output = self.model(images, reports_ids, mode='train')
-            loss = self.criterion(output, reports_ids, reports_masks)
+        for batch_idx, batch in enumerate(self.train_dataloader):
+            images_id = batch[0]
+            images = batch[1].to(self.device)
+            reports_ids = batch[2].to(self.device)
+            reports_masks = batch[3].to(self.device)
+            note_ids = batch[4].to(self.device) if len(batch) > 4 else None
+            note_masks = batch[5].to(self.device) if len(batch) > 5 else None
+            labels = batch[6].to(self.device) if len(batch) > 6 else None
+
+            output, cls_logits = self.model(images, reports_ids, note_ids=note_ids, note_mask=note_masks, mode='train')
+            loss = self.criterion(output, reports_ids, reports_masks, cls_logits, labels, lambda_cls=self.args.lambda_cls)
             train_loss += loss.item()
             self.optimizer.zero_grad()
             loss.backward()
@@ -204,10 +210,13 @@ class Trainer(BaseTrainer):
         self.model.eval()
         with torch.no_grad():
             val_gts, val_res = [], []
-            for batch_idx, (images_id, images, reports_ids, reports_masks) in enumerate(self.val_dataloader):
-                images, reports_ids, reports_masks = images.to(self.device), reports_ids.to(
-                    self.device), reports_masks.to(self.device)
-                output = self.model(images, mode='sample')
+            for batch_idx, batch in enumerate(self.val_dataloader):
+                images = batch[1].to(self.device)
+                reports_ids = batch[2].to(self.device)
+                reports_masks = batch[3].to(self.device)
+                note_ids = batch[4].to(self.device) if len(batch) > 4 else None
+                note_masks = batch[5].to(self.device) if len(batch) > 5 else None
+                output, _ = self.model(images, reports_ids=None, note_ids=note_ids, note_mask=note_masks, mode='sample')
                 reports = self.model.tokenizer.decode_batch(output.cpu().numpy())
                 ground_truths = self.model.tokenizer.decode_batch(reports_ids[:, 1:].cpu().numpy())
                 val_res.extend(reports)
@@ -219,10 +228,13 @@ class Trainer(BaseTrainer):
         self.model.eval()
         with torch.no_grad():
             test_gts, test_res = [], []
-            for batch_idx, (images_id, images, reports_ids, reports_masks) in enumerate(self.test_dataloader):
-                images, reports_ids, reports_masks = images.to(self.device), reports_ids.to(
-                    self.device), reports_masks.to(self.device)
-                output = self.model(images, mode='sample')
+            for batch_idx, batch in enumerate(self.test_dataloader):
+                images = batch[1].to(self.device)
+                reports_ids = batch[2].to(self.device)
+                reports_masks = batch[3].to(self.device)
+                note_ids = batch[4].to(self.device) if len(batch) > 4 else None
+                note_masks = batch[5].to(self.device) if len(batch) > 5 else None
+                output, _ = self.model(images, reports_ids=None, note_ids=note_ids, note_mask=note_masks, mode='sample')
                 reports = self.model.tokenizer.decode_batch(output.cpu().numpy())
                 ground_truths = self.model.tokenizer.decode_batch(reports_ids[:, 1:].cpu().numpy())
                 test_res.extend(reports)


### PR DESCRIPTION
## Summary
- support `--use_adapter` and `--use_prompt` command‑line flags
- implement adapter modules within each decoder layer
- allow learnable prompt tokens to be prepended to the fused memory

## Testing
- `python -m py_compile $(git ls-files '*.py')`
